### PR TITLE
drbd: only rmmod if DRBD is a module

### DIFF
--- a/scripts/drbd
+++ b/scripts/drbd
@@ -252,7 +252,9 @@ case "$1" in
 		if [ -d /sys/module/drbd/holders ]; then
 			(cd /sys/module/drbd/holders; for tr in *; do [ -d ${tr} ] && ${RMMOD} ${tr}; done)
 		fi
-		$RMMOD drbd && break
+		if [ ! -z "$(cat /proc/modules | grep -w drbd)" ]; then
+			$RMMOD drbd && break
+		fi
 	    fi
 	done
 	run_hook stop


### PR DESCRIPTION
Account for the case if the DRBD drive is built into
the kernel. Otherwise, errors, like the following,
will occur:

root@localhost:~# /etc/init.d/drbd stop
    Stopping all DRBD resources: ERROR: Module drbd does not exist in
    /proc/modules