### PR TITLE
al_transaction_types is already defined in drbd-headers/drbd_meta_data.h

### DIFF
--- a/user/shared/drbdmeta.c
+++ b/user/shared/drbdmeta.c
@@ -687,10 +687,6 @@ void md_cpu_to_disk_08(struct md_on_disk_08 *disk, const struct md_cpu *cpu)
 #define AL_CONTEXT_PER_TRANSACTION 919
 /* from DRBD 8.4 linux/drbd/drbd_limits.h, DRBD_AL_EXTENTS_MAX */
 #define AL_EXTENTS_MAX  65534
-enum al_transaction_types {
-	AL_TR_UPDATE = 0,
-	AL_TR_INITIALIZED = 0xffff
-};
 struct __packed al_4k_transaction_on_disk {
 	/* don't we all like magic */
 	be_u32	magic;


### PR DESCRIPTION
Calling **make** in CentOS 7.x:
```make
gcc -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic -Wall -I../../drbd-headers -I.. -I. -I../shared    -c -o drbdmeta.o ../shared/drbdmeta.c
../shared/drbdmeta.c:690:6: error: nested redefinition of ‘enum al_transaction_types’
 enum al_transaction_types {
      ^
../shared/drbdmeta.c:690:6: error: redeclaration of ‘enum al_transaction_types’
In file included from ../shared/drbdmeta.c:57:0:
../../drbd-headers/drbd_meta_data.h:56:6: note: originally defined here
 enum al_transaction_types {
      ^
../shared/drbdmeta.c:691:2: error: redeclaration of enumerator ‘AL_TR_UPDATE’
  AL_TR_UPDATE = 0,
  ^
In file included from ../shared/drbdmeta.c:57:0:
../../drbd-headers/drbd_meta_data.h:57:2: note: previous definition of ‘AL_TR_UPDATE’ was here
  AL_TR_UPDATE = 0,
  ^
../shared/drbdmeta.c:692:2: error: redeclaration of enumerator ‘AL_TR_INITIALIZED’
  AL_TR_INITIALIZED = 0xffff
  ^
In file included from ../shared/drbdmeta.c:57:0:
../../drbd-headers/drbd_meta_data.h:58:2: note: previous definition of ‘AL_TR_INITIALIZED’ was here
  AL_TR_INITIALIZED = 0xffff
  ^
make[1]: *** [drbdmeta.o] Error 1
make[1]: Leaving directory `/builddir/build/BUILD/drbd-utils-9.5.0/user/v9'
make: *** [tools] Error 2
```

This pull request just removes the duplicate definition of **al_transaction_types**.
