### PR TITLE
netlink: Add NLA_F_NESTED flag to nested attribute

### DIFF
--- a/user/shared/libgenl.h
+++ b/user/shared/libgenl.h
@@ -859,7 +859,7 @@ static inline struct nlattr *nla_nest_start(struct msg_buff *msg, int attrtype)
 {
 	struct nlattr *start = (struct nlattr *)msg->tail;
 
-	if (nla_put(msg, attrtype, 0, NULL) < 0)
+	if (nla_put(msg, attrtype | NLA_F_NESTED, 0, NULL) < 0)
 		return NULL;
 
 	return start;


### PR DESCRIPTION
The mainline kernel v5.2 commit b424e432e770
("netlink: add validation of NLA_F_NESTED flag") imposes strict validation
against nested attribute as follow.

"
Add new validation flag NL_VALIDATE_NESTED which adds three consistency
checks of NLA_F_NESTED_FLAG:

  - the flag is set on attributes with NLA_NESTED{,_ARRAY} policy
  - the flag is not set on attributes with other policies except NLA_UNSPEC
  - the flag is set on attribute passed to nla_parse_nested()
"

Sending messages with nested attribute without NLA_F_NESTED would cause failed
validation. For example,

$ drbdsetup new-resource r0
Invalid argument

This patch adds NLA_F_NESTED flag to all nested attributes.

Signed-off-by: He Zhe <zhe.he@windriver.com>