### PR TITLE
Commented out the warning message

### DIFF
--- a/user/shared/drbdmeta.c
+++ b/user/shared/drbdmeta.c
@@ -2890,7 +2890,7 @@ int meta_dump_md(struct format *cfg, char **argv __attribute((unused)), int argc
 
 	if (!al_is_clean)
 		/* So we have been forced. Still cause a parse error for restore-md. */
-		printf("This_is_an_unclean_meta_data_dump._Don't_trust_the_bitmap.\n"
+		printf("# This_is_an_unclean_meta_data_dump._Don't_trust_the_bitmap.\n"
 			"# You should \"apply-al\" first, if you plan to restore this.\n\n");
 
 	if (format_version(cfg) >= DRBD_V09)


### PR DESCRIPTION
When metadata is obtained using `drbdmeta`, the following line may be included depending on the situation.

```
This_is_an_unclean_meta_data_dump._Don't_trust_the_bitmap.
```

When you run `drbdmeta restore-md` using this metadata, the following error occurs.

```
Line 8: Unknown token: This_is_an_unclean_meta_data_dump ...
```

I thought that this would be an obstacle when I wanted to use metadata that was not clean, so I needed to comment it out. Consider merging.

Thank you