### PR TITLE
v84: Make setup_options definitions as extern

### DIFF
--- a/user/v84/drbdadm.h
+++ b/user/v84/drbdadm.h
@@ -251,7 +251,7 @@ struct setup_option {
 	bool explicit;
 	char *option;
 };
-struct setup_option *setup_options;
+extern struct setup_option *setup_options;
 
 extern void add_setup_option(bool explicit, char *option);
 


### PR DESCRIPTION
This is already defined in drbdadm_main.c, therefore make this
declaration to be extern for other modules

Fixes compatibility with gcc-10 which uses -fno-common by default

Signed-off-by: Khem Raj <raj.khem@gmail.com>