### PR TITLE
Improvements to snapshot-resync-target-lvm.sh

### DIFF
--- a/scripts/snapshot-resync-target-lvm.sh
+++ b/scripts/snapshot-resync-target-lvm.sh
@@ -169,12 +169,11 @@ else
 			:;; # ok, already exported by drbdadm
 		esac
 
-		OUT_OF_SYNC=$(sed -ne "/^ *$DRBD_MINOR:/ "'{
-				n;
-				s/^.* oos:\([0-9]*\).*$/\1/;
-				s/^$/0/; # default if not found
-				p;
-				q; }' < /proc/drbd) # unit KiB
+		OUT_OF_SYNC=$(drbdsetup events2 --statistics --now $DRBD_RESOURCE | \
+			grep "peer-device name:$DRBD_RESOURCE" | \
+			grep "volume:$DRBD_VOLUME" | \
+			grep -oP 'out-of-sync:\K[0-9]+')
+
 		SNAP_SIZE=$((OUT_OF_SYNC + SNAP_ADDITIONAL + LV_SIZE_K * SNAP_PERC / 100))
 		lvcreate -s -n $SNAP_NAME -L ${SNAP_SIZE}k $LVC_OPTIONS $VG_NAME/$LV_NAME
 	)

--- a/scripts/snapshot-resync-target-lvm.sh
+++ b/scripts/snapshot-resync-target-lvm.sh
@@ -157,6 +157,12 @@ else
 	(
 		set -e
 		[ $BE_VERBOSE = 1 ] && set -x
+
+		if lvs $VG_NAME/$SNAP_NAME > /dev/null 2>&1; then
+			echo "snapshot already exists for $DRBD_RESOURCE/$DRBD_VOLUME, skipping"
+			exit 0
+		fi
+
 		case $DRBD_MINOR in
 			*[!0-9]*|"")
 			if $is_stacked; then

--- a/scripts/snapshot-resync-target-lvm.sh
+++ b/scripts/snapshot-resync-target-lvm.sh
@@ -174,9 +174,6 @@ else
 			grep "volume:$DRBD_VOLUME" | \
 			grep -oP 'out-of-sync:\K[0-9]+')
 
-		# skip snapshot if zero blocks are out of sync
-		[ $OUT_OF_SYNC = 0 ] && exit 0
-
 		SNAP_SIZE=$((OUT_OF_SYNC + SNAP_ADDITIONAL + LV_SIZE_K * SNAP_PERC / 100))
 		lvcreate -s -n $SNAP_NAME -L ${SNAP_SIZE}k $LVC_OPTIONS $VG_NAME/$LV_NAME
 	)

--- a/scripts/snapshot-resync-target-lvm.sh
+++ b/scripts/snapshot-resync-target-lvm.sh
@@ -174,6 +174,9 @@ else
 			grep "volume:$DRBD_VOLUME" | \
 			grep -oP 'out-of-sync:\K[0-9]+')
 
+		# skip snapshot if zero blocks are out of sync
+		[ $OUT_OF_SYNC = 0 ] && exit 0
+
 		SNAP_SIZE=$((OUT_OF_SYNC + SNAP_ADDITIONAL + LV_SIZE_K * SNAP_PERC / 100))
 		lvcreate -s -n $SNAP_NAME -L ${SNAP_SIZE}k $LVC_OPTIONS $VG_NAME/$LV_NAME
 	)

--- a/scripts/snapshot-resync-target-lvm.sh
+++ b/scripts/snapshot-resync-target-lvm.sh
@@ -135,18 +135,6 @@ create_snapshot()
 		return 0
 	fi
 
-	case $DRBD_MINOR in
-		*[!0-9]*|"")
-		if $is_stacked; then
-			DRBD_MINOR=$(drbdadm -S sh-minor "$DRBD_RESOURCE")
-		else
-			DRBD_MINOR=$(drbdadm sh-minor "$DRBD_RESOURCE")
-		fi
-		;;
-	*)
-		:;; # ok, already exported by drbdadm
-	esac
-
 	OUT_OF_SYNC=$(drbdsetup events2 --statistics --now $DRBD_RESOURCE | \
 		grep "^exists peer-device name:$DRBD_RESOURCE" | \
 		grep "volume:$DRBD_VOLUME" | \


### PR DESCRIPTION
I have prepared a handful of small changes for this script, which bring fixes for working with resources composed of multiple volumes, to deal with the deprecation of `/proc/drbd` and allows the script to skip the snapshot creation altogether if it's not required.