### PR TITLE
user: drbrdmon: add missing <stdint.h> includes

### DIFF
--- a/user/drbdmon/DrbdMonConsts.h
+++ b/user/drbdmon/DrbdMonConsts.h
@@ -1,6 +1,7 @@
 #ifndef DRBDMONCONSTS_H
 #define DRBDMONCONSTS_H
 
+#include <stdint.h>
 #include <string>
 
 class DrbdMonConsts

--- a/user/drbdmon/terminal/DisplayId.h
+++ b/user/drbdmon/terminal/DisplayId.h
@@ -1,6 +1,7 @@
 #ifndef DISPLAYID_H
 #define DISPLAYID_H
 
+#include <stdint.h>
 #include <string>
 
 class DisplayId


### PR DESCRIPTION
GCC 13 drops some transitive includes within libstdc++.

Explicitly include <stdint.h> for uint32_t etc.

Note that using <stdint.h> deliberately because we're not using std::-prefixed types.