### PR TITLE
Update drbd: Script reports no such file, it shouldn't.  Fixed.

### DIFF
--- a/scripts/drbd
+++ b/scripts/drbd
@@ -172,6 +172,7 @@ handle_linstor_loopback()
 			stop)  losetup "$dev" 2>/dev/null && losetup -d "$dev";;
 		esac
 	done < "$loop_mapping"
+	return 0
 }
 
 run_hook()

--- a/scripts/drbd
+++ b/scripts/drbd
@@ -172,7 +172,6 @@ handle_linstor_loopback()
 			stop)  losetup "$dev" 2>/dev/null && losetup -d "$dev";;
 		esac
 	done < "$loop_mapping"
-	return 0
 }
 
 run_hook()

--- a/scripts/drbd
+++ b/scripts/drbd
@@ -154,26 +154,24 @@ handle_linstor_loopback()
 	# old location
 	elif [ -f /var/lib/linstor/loop_device_mapping ]; then
 		loop_mapping=/var/lib/linstor/loop_device_mapping
-	fi
-
-	if [[ "${loop_mapping}x" == "x" ]]; then
+	else
 		# at least we tried.
 		return 0
-	else
-		# || [[ -n $line ]]: in case there is no newline at EOF
-		while read -r line || [[ -n $line ]] ; do
-			dev=${line%%:*}
-			file=${line#*:}
-			test -f "$file" && test -r "$file" && test -w "$file" || continue
-			# should -f be allowed?
-			[[ $dev = loop* ]] || [[ $dev = /dev/loop* ]] || continue
-			case "$1" in
-				# what about existing, but "wrong", mappings?
-				start) losetup "$dev" 2>/dev/null || losetup "$dev" "$file";;
-				stop)  losetup "$dev" 2>/dev/null && losetup -d "$dev";;
-			esac
-		done < "$loop_mapping"
 	fi
+
+	# || [[ -n $line ]]: in case there is no newline at EOF
+	while read -r line || [[ -n $line ]] ; do
+		dev=${line%%:*}
+		file=${line#*:}
+		test -f "$file" && test -r "$file" && test -w "$file" || continue
+		# should -f be allowed?
+		[[ $dev = loop* ]] || [[ $dev = /dev/loop* ]] || continue
+		case "$1" in
+			# what about existing, but "wrong", mappings?
+			start) losetup "$dev" 2>/dev/null || losetup "$dev" "$file";;
+			stop)  losetup "$dev" 2>/dev/null && losetup -d "$dev";;
+		esac
+	done < "$loop_mapping"
 }
 
 run_hook()

--- a/scripts/drbd
+++ b/scripts/drbd
@@ -160,19 +160,19 @@ handle_linstor_loopback()
 		# at least we tried.
 		return 0
 	else
-	# || [[ -n $line ]]: in case there is no newline at EOF
-	while read -r line || [[ -n $line ]] ; do
-		dev=${line%%:*}
-		file=${line#*:}
-		test -f "$file" && test -r "$file" && test -w "$file" || continue
-		# should -f be allowed?
-		[[ $dev = loop* ]] || [[ $dev = /dev/loop* ]] || continue
-		case "$1" in
-			# what about existing, but "wrong", mappings?
-			start) losetup "$dev" 2>/dev/null || losetup "$dev" "$file";;
-			stop)  losetup "$dev" 2>/dev/null && losetup -d "$dev";;
-		esac
-	done < "$loop_mapping"
+		# || [[ -n $line ]]: in case there is no newline at EOF
+		while read -r line || [[ -n $line ]] ; do
+			dev=${line%%:*}
+			file=${line#*:}
+			test -f "$file" && test -r "$file" && test -w "$file" || continue
+			# should -f be allowed?
+			[[ $dev = loop* ]] || [[ $dev = /dev/loop* ]] || continue
+			case "$1" in
+				# what about existing, but "wrong", mappings?
+				start) losetup "$dev" 2>/dev/null || losetup "$dev" "$file";;
+				stop)  losetup "$dev" 2>/dev/null && losetup -d "$dev";;
+			esac
+		done < "$loop_mapping"
 	fi
 }
 

--- a/scripts/drbd
+++ b/scripts/drbd
@@ -149,10 +149,17 @@ handle_linstor_loopback()
 	local line dev file loop_mapping
 
 	# new location
-	loop_mapping=/var/lib/linstor.d/loop_device_mapping
-	# fallback to old location
-	[ -f "$loop_mapping" ] || loop_mapping=/var/lib/linstor/loop_device_mapping
+	if [ -f /var/lib/linstor.d/loop_device_mapping ]; then
+		loop_mapping=/var/lib/linstor.d/loop_device_mapping
+	# old location
+	elif [ -f /var/lib/linstor/loop_device_mapping ]; then
+		loop_mapping=/var/lib/linstor/loop_device_mapping
+	fi
 
+	if [[ "${loop_mapping}x" == "x" ]]; then
+		# at least we tried.
+		return 0
+	else
 	# || [[ -n $line ]]: in case there is no newline at EOF
 	while read -r line || [[ -n $line ]] ; do
 		dev=${line%%:*}
@@ -166,9 +173,7 @@ handle_linstor_loopback()
 			stop)  losetup "$dev" 2>/dev/null && losetup -d "$dev";;
 		esac
 	done < "$loop_mapping"
-
-	# at least we tried.
-	return 0
+	fi
 }
 
 run_hook()


### PR DESCRIPTION
Fixes this error (when started via sysvinit):

`Starting DRBD resources:/etc/init.d/drbd: line 148: /var/lib/linstor/loop_device_mapping: No such file or directory [
`

Related: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1030118

Though in my case I am using Devuan, which is downstream of Debian for most packages (e.g. drbd-utils)

Couple of commits, please squash.  I did this quickly only using github's interface... (script tested though) .
