### PR TITLE
user/v9: fix -Wimplicit-function-declaration

### DIFF
--- a/user/v9/drbdadm_main.c
+++ b/user/v9/drbdadm_main.c
@@ -58,6 +58,7 @@
 #include "config_flags.h"
 #include "drbdadm_dump.h"
 #include "shared_main.h"
+#include "shared_parser.h"
 #include "drbdadm_parser.h"
 
 #define MAX_ARGS 40


### PR DESCRIPTION
GCC 14 and Clang 16 make this fatal:
```
gcc -g -O2 -Wall -I../../drbd-headers -I.. -I. -I../shared    -c -o drbdadm_main.o drbdadm_main.c
drbdadm_main.c: In function ‘main’:
drbdadm_main.c:3501:17: error: implicit declaration of function ‘include_file’ [-Wimplicit-function-declaration]
 3501 |                 include_file(f, config_test);
      |                 ^~~~~~~~~~~~
```