### PR TITLE
Do not hard-code paths for scripts and helper binaries

### DIFF
--- a/scripts/Makefile.in
+++ b/scripts/Makefile.in
@@ -90,11 +90,11 @@ ifeq ($(subst both,systemd,$(initscripttype)),systemd)
 	install -d $(DESTDIR)$(systemdunitdir)
 	install -m 644 $(SYSTEMD_UNITS) $(DESTDIR)$(systemdunitdir)/
 	install -m 644 $(SYSTEMD_TEMPLATES) $(DESTDIR)$(systemdunitdir)/
-	install -d $(DESTDIR)/lib/drbd/scripts
-	install -m 755 drbd $(DESTDIR)/lib/drbd/scripts
-	install -m 755 drbd-service-shim.sh $(DESTDIR)/lib/drbd/scripts
-	install -m 755 drbd-wait-promotable.sh $(DESTDIR)/lib/drbd/scripts
-	install -m 755 ocf.ra.wrapper.sh $(DESTDIR)/lib/drbd/scripts
+	install -d $(DESTDIR)$(LIBDIR)/scripts
+	install -m 755 drbd $(DESTDIR)$(LIBDIR)/scripts
+	install -m 755 drbd-service-shim.sh $(DESTDIR)$(LIBDIR)/scripts
+	install -m 755 drbd-wait-promotable.sh $(DESTDIR)$(LIBDIR)/scripts
+	install -m 755 ocf.ra.wrapper.sh $(DESTDIR)$(LIBDIR)/scripts
 	install -d $(DESTDIR)$(tmpfilesdir)/
 	install -m 444 drbd.tmpfiles.conf $(DESTDIR)$(tmpfilesdir)/drbd.conf
 endif

--- a/user/v84/Makefile.in
+++ b/user/v84/Makefile.in
@@ -110,19 +110,19 @@ ifeq ($(WITH_84_SUPPORT),yes)
 	install -d $(DESTDIR)$(localstatedir)/lib/drbd
 	install -d $(DESTDIR)$(localstatedir)/run/drbd
 	install -d $(DESTDIR)$(localstatedir)/lock
-	install -d $(DESTDIR)/lib/drbd/
+	install -d $(DESTDIR)$(LIBDIR)/
 	if getent group haclient > /dev/null 2> /dev/null ; then	\
-		install -g haclient -m 4750 drbdsetup-84 $(DESTDIR)/lib/drbd/ ;	\
-		install -m 755 drbdadm-84 $(DESTDIR)/lib/drbd/ ;		\
+		install -g haclient -m 4750 drbdsetup-84 $(DESTDIR)$(LIBDIR)/ ;	\
+		install -m 755 drbdadm-84 $(DESTDIR)$(LIBDIR)/ ;		\
 	else								\
-		install -m 755 drbdsetup-84 $(DESTDIR)/lib/drbd/ ;		\
-		install -m 755 drbdadm-84 $(DESTDIR)/lib/drbd/ ; 		\
+		install -m 755 drbdsetup-84 $(DESTDIR)$(LIBDIR)/ ;		\
+		install -m 755 drbdadm-84 $(DESTDIR)$(LIBDIR)/ ; 		\
 	fi
 endif
 
 uninstall:
-	rm -f $(DESTDIR)/lib/drbd/drbdsetup-84
-	rm -f $(DESTDIR)/lib/drbd/drbdadm-84
+	rm -f $(DESTDIR)$(LIBDIR)/drbdsetup-84
+	rm -f $(DESTDIR)$(LIBDIR)/drbdadm-84
 
 spell:
 	for f in drbdadm_adjust.c drbdadm_main.c drbdadm_parser.c drbdadm_usage_cnt.c drbdsetup.c drbdtool_common.c; do \


### PR DESCRIPTION
Use $(LIBDIR) instead to make it user configurable.
