### PR TITLE
Fix typo in warning, there is no po4a-translage command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -332,7 +332,7 @@ else
 fi
 
 if test -z $PO4A_TRANSLATE; then
-   AC_MSG_WARN([Cannot build man pages without po4a-translage. You may safely ignore this warning when building from a tarball.])
+   AC_MSG_WARN([Cannot build man pages without po4a-translate. You may safely ignore this warning when building from a tarball.])
    dnl default to some sane value at least,
    dnl so the error message about command not found makes sense
    PO4A_TRANSLATE=po4a-translate


### PR DESCRIPTION
On a new and bare VM trying to compile drbd-utils, I saw this:

configure: WARNING: No dpkg-buildpackage found, building Debian packages is disabled.
configure: WARNING: Cannot build man pages without xsltproc. You may safely ignore this warning when building from a tarball.
configure: WARNING: Cannot run tests without clitest, disabling test target.
configure: WARNING: Cannot build man pages without po4a-translage. You may safely ignore this warning when building from a tarball.
configure: WARNING: Cannot build man pages without po4a-gettextize. You may safely ignore this warning when building from a tarball.

Searched for po4a-translage a bit until I concluded that it's a typo. Fix typo.
No change to actual code, it's properly testing for the existence of po4a-translate
