### PR TITLE
Fix build with gcc-15

### DIFF
--- a/user/drbdmon/string_matching.h
+++ b/user/drbdmon/string_matching.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <stdexcept>
+#include <cstdint>
 
 namespace string_matching
 {


### PR DESCRIPTION
To fix the following error:
In file included from string_matching.cpp:1:
./string_matching.h:10:18: error: 'uint16_t' does not name a type
   10 |     extern const uint16_t   PATTERN_LIMIT;
      |                  ^~~~~~~~
./string_matching.h:7:1: note: 'uint16_t' is defined in header '\<cstdint\>';
this is probably fixable by adding '#include \<cstdint\>'