### PR TITLE
Fix selinux policy module

### DIFF
--- a/selinux/drbd.fc
+++ b/selinux/drbd.fc
@@ -18,5 +18,6 @@
 /var/lib/drbd(/.*)?	gen_context(system_u:object_r:drbd_var_lib_t,s0)
 
 /var/lock/subsys/drbd	--	gen_context(system_u:object_r:drbd_lock_t,s0)
+/run/lock/subsys/drbd	--	gen_context(system_u:object_r:drbd_lock_t,s0)
 
 /var/run/drbd(/.*)?		gen_context(system_u:object_r:drbd_var_run_t,s0)

--- a/selinux/drbd.fc
+++ b/selinux/drbd.fc
@@ -21,3 +21,4 @@
 /run/lock/subsys/drbd	--	gen_context(system_u:object_r:drbd_lock_t,s0)
 
 /var/run/drbd(/.*)?		gen_context(system_u:object_r:drbd_var_run_t,s0)
+/run/drbd(/.*)?		gen_context(system_u:object_r:drbd_var_run_t,s0)

--- a/selinux/drbd.fc
+++ b/selinux/drbd.fc
@@ -12,8 +12,8 @@
 
 /usr/lib/ocf/resource\.d/linbit/drbd	--	gen_context(system_u:object_r:drbd_exec_t,s0)
 
-/usr/sbin/drbdadm	--	gen_context(system_u:object_r:drbd_exec_t,s0)
-/usr/sbin/drbdsetup	--	gen_context(system_u:object_r:drbd_exec_t,s0)
+/usr/s?bin/drbdadm	--	gen_context(system_u:object_r:drbd_exec_t,s0)
+/usr/s?bin/drbdsetup	--	gen_context(system_u:object_r:drbd_exec_t,s0)
 
 /var/lib/drbd(/.*)?	gen_context(system_u:object_r:drbd_var_lib_t,s0)
 


### PR DESCRIPTION
The fedora selinux policy defines ["equivalencies"](https://github.com/fedora-selinux/selinux-policy/blob/rawhide/config/file_contexts.subs_dist) between /usr/bin -> /usr/sbin, /run/lock -> /var/lock and /run -> /var/run.
These are not aliases but say "if a file is in /var/lock, it will get the type defined in /run/lock".

Thus, if a file is in /var/run/drbd/lock/, it currently does not get the type `drbd_var_run_t` but `var_run_t`, which causes issues with access to the lock file.

This hit us in openSUSE as we use the fedora selinux policy as upstream,  causing drbd_passive resource failing to start. 

fedora itself has a migration script for equivalencies in their packaging, so might not affect them right now but as far as I understand this should be migrated in the custom modules. ccing @zpytela for confirmation.

Keeping the existing file contexts in, in case other distros do not carry the equivalency rules.

References:
https://github.com/fedora-selinux/selinux-policy/commit/1be14f9b5a99a4eec7f9aba7fbb83bf8dde817f4
https://github.com/fedora-selinux/selinux-policy/commit/8973a73c7c534b51860b9350eacc6d946ab1e412
https://github.com/fedora-selinux/selinux-policy/commit/1f76e522ab3e4c6faafde161036aa5bb49a0cbe0
