### PR TITLE
snapshot-resync-target-lvm.sh: disable devicesfile when calling lvm

### DIFF
--- a/scripts/snapshot-resync-target-lvm.sh
+++ b/scripts/snapshot-resync-target-lvm.sh
@@ -64,7 +64,7 @@ fi
 set_vg_lv_size()
 {
 	local X
-	if ! X=$(lvs --config 'devices { filter=["r|/dev/drbd.*|"] }' --noheadings --nosuffix --units s -o vg_name,lv_name,lv_size "$BACKING_BDEV") ; then
+	if ! X=$(lvs --config 'devices { use_devicesfile=0 filter=["r|/dev/drbd.*|"] }' --noheadings --nosuffix --units s -o vg_name,lv_name,lv_size "$BACKING_BDEV") ; then
 		# if lvs cannot tell me the info I need,
 		# this is:
 		echo "Cannot create snapshot of $BACKING_BDEV, apparently no LVM LV."
@@ -150,7 +150,7 @@ else
 				p;
 				q; }' < /proc/drbd) # unit KiB
 		SNAP_SIZE=$((OUT_OF_SYNC + SNAP_ADDITIONAL + LV_SIZE_K * SNAP_PERC / 100))
-		lvcreate --config 'devices { filter=["r|/dev/drbd.*|"] }' -s -n $SNAP_NAME -L ${SNAP_SIZE}k $LVC_OPTIONS $VG_NAME/$LV_NAME
+		lvcreate --config 'devices { use_devicesfile=0 filter=["r|/dev/drbd.*|"] }' -s -n $SNAP_NAME -L ${SNAP_SIZE}k $LVC_OPTIONS $VG_NAME/$LV_NAME
 	)
 	RV=$?
 	[ $DISCONNECT_ON_ERROR = 0 ] && exit 0


### PR DESCRIPTION
In Red Hat 9+, the `devices/use_devicesfile` setting is enabled by default (`=1`). However when the devicesfile is enabled, the `devices/filter` and `devices/global_filter` are ineffective.

Running this command manually results in the following warning:

```
Please remove the lvm.conf filter, it is ignored with the devices
```

This has the unfortunate side-effect of triggering the hanging lvm commands that this filter is intending to avoid. We have seen on our machines that after a reboot drbd fails to connect. It claims there is a network error while in reality the lvm commands run in this script are hanging until a timeout occurs. Disabling the
`devices/use_devicesfile` setting (`=0`) in `lvm.conf` resolved this problem.

The DRBD-9 documentation makes no mention of the `devices/use_devicesfile` setting. It mentions the filter and global_filter, but with the Red Hat 9+ default setting of `devices/use_devicesfile=1` neither of these settings is actually effective. The documentation does mention the `devices/write_cache_state` setting, but this setting was removed in lvm v2.03. I therefore feel the documentation might need to be updated.

This change works around the original problem we encountered by ensuring that the `devices/use_devicesfile` setting is disabled when running the lvm commands in the `snapshot-resync-target-lvm.sh` script. This works as an alternative to globally disabling the devicesfile in `/etc/lvm/lvm.conf`.