### PR TITLE
Delete the file first and then unlock. The order should be reversed.

### DIFF
--- a/scripts/tnf-drbd-fence.py
+++ b/scripts/tnf-drbd-fence.py
@@ -189,8 +189,8 @@ def fence_peer_exclusive(res):
                     msg, code = fence_peer(res)
                     print('{}§{}'.format(code, msg), file=fw)
                 finally:
-                    os.remove(LOCK_FILE)
                     fcntl.flock(fw.fileno(), fcntl.LOCK_UN)
+                    os.remove(LOCK_FILE)
             break
         except FileExistsError:
             try:


### PR DESCRIPTION
After executing os.remove(), although the file descriptor fw.fileno() still exists, the following is true: 
1.Unlock operation is invalid (file descriptor has expired) .
2.The lock is actually released automatically when the file is closed, but the disorderly sequence may cause an exception. 
3.It breaks the lock's mutual exclusion guarantee.